### PR TITLE
Finish URL loading when observing requests to make sure all URL reque…

### DIFF
--- a/CI.xctestplan
+++ b/CI.xctestplan
@@ -18,7 +18,8 @@
         }
       ]
     },
-    "testExecutionOrdering" : "random"
+    "testExecutionOrdering" : "random",
+    "threadSanitizerEnabled" : true
   },
   "testTargets" : [
     {

--- a/EssentialFeed2.xctestplan
+++ b/EssentialFeed2.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-
+    "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {

--- a/EssentialFeed2Tests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed2Tests/Feed API/URLSessionHTTPClientTests.swift
@@ -176,7 +176,6 @@ extension URLSessionHTTPClientTests {
         }
 
         override class func canInit(with request: URLRequest) -> Bool {
-            requestObserver?(request)
             return true
         }
 
@@ -185,6 +184,11 @@ extension URLSessionHTTPClientTests {
         }
 
         override func startLoading() {
+            if let requestObserver = URLProtocolStub.requestObserver {
+                client?.urlProtocolDidFinishLoading(self)
+                return requestObserver(request)
+            }
+
             if let data = URLProtocolStub.stub?.data {
                 client?.urlProtocol(self, didLoad: data)
             }


### PR DESCRIPTION
Finish URL loading when observing requests to make sure all URL requests are finished before the test method returns. This way, we prevent data races with threads living longer than the test method that initiated them.