### PR TITLE
Test-driving Cache Invalidation + Identifying Complex (Bloated) Functionality With The Command–Query Separation Principle

### DIFF
--- a/EssentialFeed2/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed2/FeedCache/LocalFeedLoader.swift
@@ -38,6 +38,7 @@ public final class LocalFeedLoader {
     store.retrieve { [unowned self] result in
       switch result {
       case let .failure(error):
+        self.store.deleteCacheFeed { _ in }
         completion(.failure(error))
       case let .found(feed, timestamp) where self.validate(timestamp):
         completion(.success(feed.toModels()))

--- a/EssentialFeed2/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed2/FeedCache/LocalFeedLoader.swift
@@ -42,7 +42,10 @@ public final class LocalFeedLoader {
         completion(.failure(error))
       case let .found(feed, timestamp) where self.validate(timestamp):
         completion(.success(feed.toModels()))
-      case .found, .empty:
+      case .found:
+        self.store.deleteCacheFeed { _ in }
+        completion(.success([]))
+      case .empty:
         completion(.success([]))
       }
     }

--- a/EssentialFeed2/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed2/FeedCache/LocalFeedLoader.swift
@@ -35,7 +35,8 @@ public final class LocalFeedLoader {
   }
 
   public func load(completion: @escaping (LoadResult) -> Void) {
-    store.retrieve { [unowned self] result in
+    store.retrieve { [weak self] result in
+      guard let self else { return }
       switch result {
       case let .failure(error):
         self.store.deleteCacheFeed { _ in }

--- a/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -72,6 +72,15 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
       store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp)
     })
   }
+
+  func test_load_deletesCacheOnRetrievalError() {
+    let (sut, store) = makeSUT()
+
+    sut.load { _ in }
+    store.completeRetrieval(with: anyNSError())
+
+    XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCacheFeed])
+  }
 }
 
 extension LoadFeedFromCacheUseCaseTests {

--- a/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -126,6 +126,19 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
 
     XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCacheFeed])
   }
+
+  func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
+    let store = FeedStoreSpy()
+    var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
+
+    var receivedResults = [LocalFeedLoader.LoadResult]()
+    sut?.load { receivedResults.append($0) }
+
+    sut = nil
+    store.completeRetrievalWithEmptyCache()
+
+    XCTAssertTrue(receivedResults.isEmpty)
+  }
 }
 
 extension LoadFeedFromCacheUseCaseTests {

--- a/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -91,7 +91,7 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
     XCTAssertEqual(store.receivedMessages, [.retrieve])
   }
 
-  func test_load_devliversNoImageOnLessThanSevenDaysOldCache() {
+  func test_load_doesNotDeleteCacheOnLessThanSevenDaysOldCache() {
     let feed = uniqueImageFeed()
     let fixedCurrentDate = Date()
     let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
@@ -101,6 +101,18 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
     store.completeRetrieval(with: feed.local, timestamp: lessThanSevenDaysOldTimestamp)
 
     XCTAssertEqual(store.receivedMessages, [.retrieve])
+  }
+
+  func test_load_deletesCacheOnSevenDaysOldCache() {
+    let feed = uniqueImageFeed()
+    let fixedCurrentDate = Date()
+    let sevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7)
+    let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+
+    sut.load { _ in }
+    store.completeRetrieval(with: feed.local, timestamp: sevenDaysOldTimestamp)
+
+    XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCacheFeed])
   }
 }
 

--- a/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -81,6 +81,15 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
 
     XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCacheFeed])
   }
+
+  func test_load_doesNotDeleteCacheOnEmptyCache() {
+    let (sut, store) = makeSUT()
+
+    sut.load { _ in }
+    store.completeRetrievalWithEmptyCache()
+
+    XCTAssertEqual(store.receivedMessages, [.retrieve])
+  }
 }
 
 extension LoadFeedFromCacheUseCaseTests {

--- a/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -90,6 +90,18 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
 
     XCTAssertEqual(store.receivedMessages, [.retrieve])
   }
+
+  func test_load_devliversNoImageOnLessThanSevenDaysOldCache() {
+    let feed = uniqueImageFeed()
+    let fixedCurrentDate = Date()
+    let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+    let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+
+    sut.load { _ in }
+    store.completeRetrieval(with: feed.local, timestamp: lessThanSevenDaysOldTimestamp)
+
+    XCTAssertEqual(store.receivedMessages, [.retrieve])
+  }
 }
 
 extension LoadFeedFromCacheUseCaseTests {

--- a/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed2Tests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -114,6 +114,18 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
 
     XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCacheFeed])
   }
+
+  func test_load_deletesCacheOnMoreThanSevenDaysOldCache() {
+    let feed = uniqueImageFeed()
+    let fixedCurrentDate = Date()
+    let moreThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(days: -1)
+    let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
+
+    sut.load { _ in }
+    store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp)
+
+    XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCacheFeed])
+  }
 }
 
 extension LoadFeedFromCacheUseCaseTests {


### PR DESCRIPTION
Test-driving Cache Invalidation + Identifying Complex (Bloated) Functionality With The Command–Query Separation Principle